### PR TITLE
Fixed syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  list: require('./list');
+  list: require('./list')
 }


### PR DESCRIPTION
When doing `require("emoji-list")` I got the following error:
```
  list: require('./list');
                         ^

SyntaxError: Unexpected token ;
```

Removing the `;` fixes it.